### PR TITLE
Introduce plugin to handle scripts (branch yem/scripts)

### DIFF
--- a/README
+++ b/README
@@ -37,7 +37,10 @@ underscores and numbers.
 
 A plugin must contain a docstring at the module-level, that provides
 the help text for that plugin, help text that will be displayed in the
-output of `aa-scan3 --help` in a section dedicated to that plugin.
+output of `aa-scan3 --help` in a section dedicated to that plugin. The
+help text is reformatted to fit in the screen, existing paragraphs are
+retained, and lines starting with +*+ and +-+ are rendered as bullet
+lists and numbered lists, respectively.
 
 A plugin must declare a class named `Scanner`. The constructor for that
 class must accept a single parameter, `parser`, which is an object that

--- a/README
+++ b/README
@@ -100,6 +100,10 @@ methods:
   to `add_path()`, `add_capability()`, or `add_network()` will apply to
   the main profile.
 
+* `joinpath(*components)`: like `os.path.join()`, except components
+  with a leading '/' do not ignore previous components. For
+  example, `joinpath('/foo', '/bar')` will yield `/boo/bar`.
+
 The `logger` attribute is callable, which is equivalent to calling
 `logger.debug()`.
 

--- a/aa-scan3
+++ b/aa-scan3
@@ -90,7 +90,7 @@ def main():
 
     for plugin in sorted(plugins):
         p = aa_scan3.plugins.plugins[plugin]
-        group = parser.add_argument_group(title='Plugin {} [{}]'.format(plugin,
+        group = parser.add_argument_group(title='plugin {} [{}]'.format(plugin,
                                                                         ', '.join(plugins[plugin]['type'])),
                                           description=p.__doc__)
         plugins[plugin]["scanner"] = p.Scanner(aa_scan3.utils.AAScanArgParser._ArgGroupPlugin(plugin,

--- a/aa_scan3/plugins/script.py
+++ b/aa_scan3/plugins/script.py
@@ -1,0 +1,25 @@
+"""
+Complete the AppArmor profile with the rules required for the
+interpreter of a script (e.g. shell, python, node...)
+"""
+
+class Scanner:
+    def __init__(self, parser):
+        parser.add_argument('--self-read', action='store_true',
+                            help='Add a rule that allows the interpreter to read'
+                            + ' itself. This is needed when e.g. it is linked'
+                            + ' with -zrelro or -znow.')
+
+    def once(self, path):
+        with open(self.profile.joinpath(self.root_dir, path), 'rb') as f:
+            blob = f.read()
+        if blob[:2] != b'#!':
+            return []
+        interpreter = blob.splitlines()[0][2:].decode().lstrip()
+        if interpreter.split()[0] == '/usr/bin/env':
+            self.logger.critical('nested interpreter {!r} not supported'.format(interpreter))
+        self.profile.add_path(path, 'r')
+        self.logger('adding interpreter {!r}'.format(interpreter))
+        if self.self_read:
+            self.profile.add_path(interpreter, 'r')
+        return [interpreter]

--- a/aa_scan3/plugins/snippet.py
+++ b/aa_scan3/plugins/snippet.py
@@ -10,6 +10,12 @@
 """
 Test if the file has associated AppArmor snippets in .aa files.
 
+Snippets are located in the `staging` directory, and are named
+after the file they apply to, with any `.aa*` extension added.
+For example, when scanning file `/bin/foo`, any file that matches
+`/bin/foo.aa*` will be considered a snippet that contains rules
+to be included in the profile.
+
 A snippet file contains one or more pattern-rules, one per line.
 No sanity-check is done on the file, and each line must end with
 a new-line '\\n' character (even the last one).

--- a/aa_scan3/plugins/snippet.py
+++ b/aa_scan3/plugins/snippet.py
@@ -67,7 +67,8 @@ class Scanner:
                     path, mode = re.split(' +', l)
                     self.profile.add_path(path, mode)
                     if 'm' in mode:
-                        yield path
+                        if '*' not in path:
+                            yield path
                 elif l.startswith('capability '):
                     self.logger('    -> is a capability')
                     _, cap = re.split(' +', l)

--- a/aa_scan3/plugins/snippet.py
+++ b/aa_scan3/plugins/snippet.py
@@ -58,21 +58,27 @@ class Scanner:
             yield from self.read_one_snippet(snippet)
 
     def read_one_snippet(self, snippet):
-        self.logger('>>{}<<'.format(snippet))
+        self.logger('parsing snippet {!r}'.format(snippet))
         with open(snippet, 'r') as f:
             for l in (l.strip().rstrip(',') for l in f):
+                self.logger('  parsing line {!r}'.format(l))
                 if l.startswith('/'):
+                    self.logger('    -> is a path')
                     path, mode = re.split(' +', l)
                     self.profile.add_path(path, mode)
                     if 'm' in mode:
                         yield path
                 elif l.startswith('capability '):
+                    self.logger('    -> is a capability')
                     _, cap = re.split(' +', l)
                     self.profile.add_capability(cap)
                 elif l.startswith('network '):
+                    self.logger('    -> is a network')
                     _, domain, proto = re.split(' +', l)
                     self.profile.add_network(domain, proto)
                 elif l.startswith('profile '):
+                    self.logger('    -> starts a child profile')
                     self.profile.start_child_profile(re.split(' +', l)[-2])
                 elif l.startswith('}'):
+                    self.logger('    -> ends a child profile')
                     self.profile.end_child_profile()


### PR DESCRIPTION
### What's new: ###

* extended formatting in help text
* generate rules for the interpreter of a script
* optional wildcard expansion in snippets

---
**How to test:**

1. Test numbered-list rendering, navigate to the help section for the _snippet_ plugin:
    ```sh
    $ ./aa-scan3 --help |less
    ```
2. Test generation of a profile for a script:
    1. create a test script:
        ```sh
        $ cat <<_EOF_ >/path/to/your/root-dir/bin/test.sh
        #!/bin/sh
        echo OK
        _EOF_
        ```
    2. create a snippet for the interpreter:
        ```sh
        printf '/foo r,\n' >/path/to/your/staging-dir/bin/sh.aa.foo
        ```
    3. generate the profile:
        ```sh
        $ ./aa-scan3 --root-dir /path/to/your/root-dir/ \
                     --staging-dir /path/to/your/staging-dir/ \
                     --script-self-read \
                     /bin/test.sh
        ```
3. Test wildcard expansion (as a continuation of the above test):
    1. create a snippet with a wildcard:
        ```sh
        printf '/usr/lib/libcr*.so* mr,\n' >/path/to/your/staging-dir/bin/sh.aa.wildcard
        ```
    2. generate the profile:
        ```sh
        $ ./aa-scan3 --root-dir /path/to/your/root-dir/ \
                     --staging-dir /path/to/your/staging-dir/ \
                     --script-self-read \
                     --snippet-expand-wildcards \
                     /bin/test.sh
        ```

----
**Expected results:**

1. The list entries are properly numbered:
    ```
    1. a path that is exactly '/**', is not expanded;

    2. paths are expanded relative to root_dir (as specified with the global
       option --root-dir);

    3. the '**' stem only matches arbitrarily deep directory components, but
       does not match any file; for example '/foo/**.bar' will find the
       directories '/foo/.bar/', '/foo/a.bar/', and '/foo/b/c/d.bar/', but
       will not find the files '/foo/0.bar', or '/foo/1/2/3.bar', or
       '/foo/1/2/3/.bar'. To match files at any arbitrary depth, use both
       '**' and '*'; for example, '/foo/**/*.bar' will find both the
       directories and the files listed above. This is a deviation from how
       AppArmor interprets '**'.
    ```
2. The profile is generated, e.g.:
    ```
    /bin/test.sh {
        /bin/sh r,
        /bin/test.sh r,
        /foo r,
        /lib/ld-linux.so mr,
        /lib/libc.so.6 mr,
    }
    ```
3. The profile is generated, with dependencies of additional shared libraries, e.g.:
    ```
    /bin/test.sh {
        /bin/sh r,
        /bin/test.sh r,
        /foo r,
        /lib/ld-linux.so mr,
        /lib/libc.so.6 mr,
        /lib/libdl.so.2
        /lib/libpthread.so.0 mr,
        /usr/lib/libcr*.so* mr,
    }
    ```
