### PR TITLE
plugins/script: support shabang with interpreter option

### DIFF
--- a/aa_scan3/plugins/script.py
+++ b/aa_scan3/plugins/script.py
@@ -19,6 +19,7 @@ class Scanner:
         if interpreter.split()[0] == '/usr/bin/env':
             self.logger.critical('nested interpreter {!r} not supported'.format(interpreter))
         self.profile.add_path(path, 'r')
+        interpreter = interpreter.split()[0]
         self.logger('adding interpreter {!r}'.format(interpreter))
         if self.self_read:
             self.profile.add_path(interpreter, 'r')


### PR DESCRIPTION
What's new:

* Fixes: #5 (plugin/script: interpreter option ends up in profile)

---
**How to test:**

1. Create a test script:
    ```sh
    $ cat <<_EOF_ >/path/to/your/root-dir/bin/test.sh
    #!/bin/sh -il
    echo OK
    _EOF_
    ```
2. Generate the profile:
    ```sh
    $ ./aa-scan3 --root-dir /path/to/your/root-dir/ \
                 --staging-dir /path/to/your/staging-dir/ \
                 --script-self-read \
                 /bin/test.sh
    ```

---
**Expected results:**

1. The script is created
2. The profile is generated, the rule for the interpreter is correct:
    ```
    /bin/test.sh {
        /bin/sh r,
        /bin/test.sh r,
        /foo r,
        /lib/ld-linux.so mr,
        /lib/libc.so.6 mr,
    }
    ```